### PR TITLE
feat: reasoning effort と reasoning summary オプションを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ CodeXにモデルgpt-5、サンドボックスモードで「このコードを�
 | `model` | string | ❌ | `gpt-5` | 使用モデル |
 | `sandbox` | boolean | ❌ | `true` | サンドボックスモード |
 | `yolo` | boolean | ❌ | `false` | 全自動モード |
+| `reasoningEffort` | string | ❌ | `medium` | 推論レベル (`none`\|`low`\|`medium`\|`high`) |
+| `reasoningSummary` | string | ❌ | `none` | 推論要約 (`none`\|`auto`) |
 
 ### Analyze File Tool
 
@@ -81,11 +83,21 @@ CodeXにモデルgpt-5、サンドボックスモードで「このコードを�
 | `model` | string | ❌ | `gpt-5` | 使用モデル |
 | `sandbox` | boolean | ❌ | `true` | サンドボックスモード |
 | `yolo` | boolean | ❌ | `false` | 全自動モード |
+| `reasoningEffort` | string | ❌ | `medium` | 推論レベル (`none`\|`low`\|`medium`\|`high`) |
+| `reasoningSummary` | string | ❌ | `none` | 推論要約 (`none`\|`auto`) |
 
 ### オプション説明
 
 - **sandbox**: `true` → `--sandbox workspace-write` (ワークスペース内のみ安全に実行)
 - **yolo**: `true` → `--full-auto` (確認なしで自動実行、**注意して使用**)
+- **reasoningEffort**: 推論レベルを制御 → `-c model_reasoning_effort=値`
+  - `none`: 推論なし（最速）
+  - `low`: 軽微な推論
+  - `medium`: 標準推論（デフォルト）
+  - `high`: 詳細な推論（最も時間がかかる）
+- **reasoningSummary**: 推論要約の表示制御 → `-c model_reasoning_summary=値`
+  - `none`: 推論要約なし（デフォルト）
+  - `auto`: 自動で推論要約を表示
 
 ## 実行されるコマンド
 
@@ -93,10 +105,23 @@ CodeXにモデルgpt-5、サンドボックスモードで「このコードを�
 
 ```bash
 # Chat Tool
-codex exec --skip-git-repo-check [--model gpt-5] [--sandbox workspace-write] [--full-auto] "プロンプト"
+codex exec --skip-git-repo-check [--model gpt-5] [--sandbox workspace-write] [--full-auto] [-c model_reasoning_effort=値] [-c model_reasoning_summary=値] "プロンプト"
 
 # Analyze File Tool
-codex exec --skip-git-repo-check [オプション] "カスタムプロンプト. Please analyze the file: ファイルパス"
+codex exec --skip-git-repo-check [オプション] [-c model_reasoning_effort=値] [-c model_reasoning_summary=値] "カスタムプロンプト. Please analyze the file: ファイルパス"
+```
+
+### 実行例
+
+```bash
+# 基本的なチャット
+codex exec --skip-git-repo-check --sandbox workspace-write "Hello CodeX"
+
+# 高精度推論付きチャット
+codex exec --skip-git-repo-check --sandbox workspace-write -c model_reasoning_effort=high -c model_reasoning_summary=auto "複雑な問題を解決して"
+
+# 高速チャット（推論なし）
+codex exec --skip-git-repo-check --sandbox workspace-write -c model_reasoning_effort=none "簡単な質問"
 ```
 
 ## 開発

--- a/index.ts
+++ b/index.ts
@@ -47,6 +47,16 @@ const tools: Tool[] = [
           type: "boolean",
           description: "Automatically accept all actions (optional)",
         },
+        reasoningEffort: {
+          type: "string",
+          description: "Model reasoning effort level (optional, default: medium)",
+          enum: ["none", "low", "medium", "high"],
+        },
+        reasoningSummary: {
+          type: "string",
+          description: "Model reasoning summary mode (optional, default: none)",
+          enum: ["none", "auto"],
+        },
       },
       required: ["prompt"],
     },
@@ -76,6 +86,16 @@ const tools: Tool[] = [
         yolo: {
           type: "boolean",
           description: "Automatically accept all actions (optional)",
+        },
+        reasoningEffort: {
+          type: "string",
+          description: "Model reasoning effort level (optional, default: medium)",
+          enum: ["none", "low", "medium", "high"],
+        },
+        reasoningSummary: {
+          type: "string",
+          description: "Model reasoning summary mode (optional, default: none)",
+          enum: ["none", "auto"],
         },
       },
       required: ["filePath"],

--- a/tools/analyzeFile.integration.test.ts
+++ b/tools/analyzeFile.integration.test.ts
@@ -50,6 +50,8 @@ describe("analyzeFileTool Integration Tests", () => {
       model?: string;
       sandbox?: boolean;
       yolo?: boolean;
+      reasoningEffort?: "none" | "low" | "medium" | "high";
+      reasoningSummary?: "none" | "auto";
     }) {
       const args: string[] = [];
 
@@ -63,6 +65,14 @@ describe("analyzeFileTool Integration Tests", () => {
 
       if (options.yolo) {
         args.push("--full-auto");
+      }
+
+      if (options.reasoningEffort && options.reasoningEffort !== "medium") {
+        args.push("-c", `model_reasoning_effort=${options.reasoningEffort}`);
+      }
+
+      if (options.reasoningSummary && options.reasoningSummary !== "none") {
+        args.push("-c", `model_reasoning_summary=${options.reasoningSummary}`);
       }
 
       // Build the analysis prompt
@@ -117,6 +127,30 @@ describe("analyzeFileTool Integration Tests", () => {
       "--full-auto",
       "Review code quality. Please analyze the file: /resolved/app.js",
     ]);
+
+    // Test reasoning options
+    expect(
+      buildCodexArgsForFile({
+        filePath: "/resolved/test.ts",
+        reasoningEffort: "high",
+        reasoningSummary: "auto",
+      }),
+    ).toEqual([
+      "-c",
+      "model_reasoning_effort=high",
+      "-c",
+      "model_reasoning_summary=auto",
+      "Please analyze this file: /resolved/test.ts",
+    ]);
+
+    // Test default reasoning options (should not appear in args)
+    expect(
+      buildCodexArgsForFile({
+        filePath: "/resolved/test.ts",
+        reasoningEffort: "medium",
+        reasoningSummary: "none",
+      }),
+    ).toEqual(["Please analyze this file: /resolved/test.ts"]);
   });
 
   it("should validate file existence check logic", () => {

--- a/tools/analyzeFile.ts
+++ b/tools/analyzeFile.ts
@@ -10,12 +10,14 @@ interface AnalyzeFileArgs {
   model?: string;
   sandbox?: boolean;
   yolo?: boolean;
+  reasoningEffort?: "none" | "low" | "medium" | "high";
+  reasoningSummary?: "none" | "auto";
 }
 
 export async function analyzeFileTool(
   args: AnalyzeFileArgs,
 ): Promise<CallToolResult> {
-  const { filePath, prompt, model, sandbox = true, yolo = false } = args;
+  const { filePath, prompt, model, sandbox = true, yolo = false, reasoningEffort = "medium", reasoningSummary = "none" } = args;
 
   // Check if file exists
   if (!existsSync(filePath)) {
@@ -42,6 +44,14 @@ export async function analyzeFileTool(
 
     if (yolo) {
       codexArgs.push("--full-auto");
+    }
+
+    if (reasoningEffort !== "medium") {
+      codexArgs.push("-c", `model_reasoning_effort=${reasoningEffort}`);
+    }
+
+    if (reasoningSummary !== "none") {
+      codexArgs.push("-c", `model_reasoning_summary=${reasoningSummary}`);
     }
 
     // Build the prompt with file analysis request

--- a/tools/chat.integration.test.ts
+++ b/tools/chat.integration.test.ts
@@ -41,6 +41,8 @@ describe("chatTool Integration Tests", () => {
       model?: string;
       sandbox?: boolean;
       yolo?: boolean;
+      reasoningEffort?: "none" | "low" | "medium" | "high";
+      reasoningSummary?: "none" | "auto";
     }) {
       const args: string[] = [];
 
@@ -54,6 +56,14 @@ describe("chatTool Integration Tests", () => {
 
       if (options.yolo) {
         args.push("--full-auto");
+      }
+
+      if (options.reasoningEffort && options.reasoningEffort !== "medium") {
+        args.push("-c", `model_reasoning_effort=${options.reasoningEffort}`);
+      }
+
+      if (options.reasoningSummary && options.reasoningSummary !== "none") {
+        args.push("-c", `model_reasoning_summary=${options.reasoningSummary}`);
       }
 
       args.push(options.prompt);
@@ -98,6 +108,29 @@ describe("chatTool Integration Tests", () => {
       "--full-auto",
       "Complex test",
     ]);
+
+    // Test reasoning options
+    expect(
+      buildCodexArgs({
+        prompt: "Test with reasoning",
+        reasoningEffort: "high",
+        reasoningSummary: "auto",
+      }),
+    ).toEqual([
+      "-c",
+      "model_reasoning_effort=high",
+      "-c", 
+      "model_reasoning_summary=auto",
+      "Test with reasoning",
+    ]);
+
+    expect(
+      buildCodexArgs({
+        prompt: "Test with default reasoning",
+        reasoningEffort: "medium",  // Should not appear in args
+        reasoningSummary: "none",   // Should not appear in args
+      }),
+    ).toEqual(["Test with default reasoning"]);
   });
 
   it("should validate spawn options structure", () => {

--- a/tools/chat.ts
+++ b/tools/chat.ts
@@ -7,10 +7,12 @@ interface ChatArgs {
   model?: string;
   sandbox?: boolean;
   yolo?: boolean;
+  reasoningEffort?: "none" | "low" | "medium" | "high";
+  reasoningSummary?: "none" | "auto";
 }
 
 export async function chatTool(args: ChatArgs): Promise<CallToolResult> {
-  const { prompt, model, sandbox = true, yolo = false } = args;
+  const { prompt, model, sandbox = true, yolo = false, reasoningEffort = "medium", reasoningSummary = "none" } = args;
 
   try {
     const codexArgs = [CODEX_EXEC_SUBCOMMAND, SKIP_GIT_REPO_CHECK_FLAG];
@@ -25,6 +27,14 @@ export async function chatTool(args: ChatArgs): Promise<CallToolResult> {
 
     if (yolo) {
       codexArgs.push("--full-auto");
+    }
+
+    if (reasoningEffort !== "medium") {
+      codexArgs.push("-c", `model_reasoning_effort=${reasoningEffort}`);
+    }
+
+    if (reasoningSummary !== "none") {
+      codexArgs.push("-c", `model_reasoning_summary=${reasoningSummary}`);
     }
 
     codexArgs.push(prompt);


### PR DESCRIPTION
## 概要

MCPツールにCodeX CLIの推論制御オプションを追加しました。

## 追加された機能

### 新しいパラメータ

- **`reasoningEffort`**: 推論レベルを制御
  - 利用可能な値: `"none"` | `"low"` | `"medium"` | `"high"`
  - デフォルト: `"medium"`
  - CodeX CLIの `-c model_reasoning_effort=値` オプションに対応

- **`reasoningSummary`**: 推論要約の表示制御
  - 利用可能な値: `"none"` | `"auto"`
  - デフォルト: `"none"`
  - CodeX CLIの `-c model_reasoning_summary=値` オプションに対応

### 対応ツール

- **Chat Tool**: 対話機能に推論制御を追加
- **Analyze File Tool**: ファイル分析機能に推論制御を追加

## 技術的変更

### 主な変更ファイル

- `index.ts`: MCPツールスキーマに新オプション追加
- `tools/chat.ts`: chatツール実装更新
- `tools/analyzeFile.ts`: analyzeFileツール実装更新
- `README.md`: ドキュメント更新

### テスト更新

- `tools/chat.integration.test.ts`: 新オプションのテストケース追加
- `tools/analyzeFile.integration.test.ts`: 新オプションのテストケース追加
- `tests/e2e.test.ts`: E2Eテストの更新とデバッグ出力改善

## 使用例

### 高精度推論
```
CodeXに推論レベル"high"で「複雑な問題を解決して」と聞いて
```

### 高速処理
```
CodeXに推論レベル"none"で「2+2は？」と聞いて
```

### 推論要約付き
```
CodeXに推論レベル"high"、推論要約"auto"で分析して
```

## 生成されるコマンド例

```bash
# 高精度推論付き
codex exec --skip-git-repo-check --sandbox workspace-write -c model_reasoning_effort=high -c model_reasoning_summary=auto "複雑な問題"

# 高速処理
codex exec --skip-git-repo-check --sandbox workspace-write -c model_reasoning_effort=none "簡単な質問"
```

## テスト

全てのテストケースが新オプションに対応し、正常に動作することを確認済みです。

🤖 Generated with [Claude Code](https://claude.ai/code)